### PR TITLE
Sync/subscribe user characteristics tags

### DIFF
--- a/app/Console/Commands/UsersSubscribeCharacteristicsTags.php
+++ b/app/Console/Commands/UsersSubscribeCharacteristicsTags.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Src\UseCases\Domain\Forum\CharacteristicsForumSyncer;
+use App\Src\UseCases\Domain\Context\Model\Characteristic;
+use DB;
+use Illuminate\Console\Command;
+
+class UsersSubscribeCharacteristicsTags extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'characteristics:init-users-subscriptions';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Subscribes every users to the characteristics (forum) tags they have in their profile.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(CharacteristicsForumSyncer $forumSyncer): void
+    {
+        // Get eligible users (subscribed to Discourse + having 1+ characteristics)
+        // Eloquent seems not to be optimized to user INNER JOIN in order to filter, using SQL
+        $usersInfosQuery = DB::table('users', 'u')
+            ->select('u.discourse_username', 'u.wiki')
+            ->addSelect('characteristics.code AS char_title', 'characteristics.pretty_page_label AS char_label')
+            ->join('user_characteristics', 'user_characteristics.user_id', '=', 'u.id')
+            ->join('characteristics', 'characteristics.id', '=', 'user_characteristics.characteristic_id')
+            ->whereNotNull('u.discourse_id')
+            ->where('u.discourse_username', '!=', '')
+            ->whereIn('characteristics.type', [Characteristic::FARMING_TYPE, Characteristic::CROPPING_SYSTEM])
+        ;
+
+        $users = $usersInfosQuery->get();
+
+        foreach ($users->all() as $user) {
+            $forumSyncer->subscribeCharacteristicTagNotifications(
+                $user->discourse_username,
+                $user->wiki,
+                $user->char_label ?? $user->char_title
+            );
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -24,11 +24,12 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command('characteristics:import')->dailyAt('22:00');
-        $schedule->command('pages:import-all')->dailyAt('02:00');
-        $schedule->command('pages:import-additional-page-detail')->twiceMonthly();
         $schedule->command('pages:sync-dry')->hourly();
+        $schedule->command('pages:import-all')->dailyAt('02:00');
+        $schedule->command('characteristics:import')->dailyAt('22:00');
+        $schedule->command('characteristics:init-users-subscriptions --since-x-days=3')->dailyAt('22:15');
         $schedule->command('users:sync-on-discourse')->dailyAt('22:30');
+        $schedule->command('pages:import-additional-page-detail')->twiceMonthly();
     }
 
     /**

--- a/app/Src/ForumApiClient.php
+++ b/app/Src/ForumApiClient.php
@@ -103,4 +103,24 @@ class ForumApiClient
 
         return json_decode($result->getBody()->getContents(), true);
     }
+
+    public function subscribeTagNotifications(string $username, string $tagName): array
+    {
+        $result = $this->client->put(
+            'tag/' . urlencode($tagName) . '/notifications',
+            [
+                'form_params' => [
+                    'tag_notification' => [
+                        'notification_level' => '2',
+                    ],
+                ],
+                // Replaces API-Username header by user username
+                'headers' => [
+                    'Api-Username' => $username,
+                ]
+            ]
+        );
+
+        return json_decode($result->getBody()->getContents(), true);
+    }
 }

--- a/app/Src/UseCases/Domain/Forum/ForumTagHelper.php
+++ b/app/Src/UseCases/Domain/Forum/ForumTagHelper.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Src\UseCases\Domain\Forum;
+
+use Illuminate\Support\Str;
+
+class ForumTagHelper
+{
+    /**
+     * Based on what we deduced from the Discourse tag names treatment :
+     * - squish extra spaces
+     * - keeps uppercase and accentuation
+     * - replaces spaces with dashes
+     */
+    public static function sanitizeTagName(string $tagName): string
+    {
+        $squishedName = Str::squish($tagName);
+        $dashedName = str_replace(' ', '-', $squishedName);
+
+        // \pL - matches any kind of letter from any language
+        // \pM - matches a character intended to be combined with another character (e.g. accents, umlauts, enclosing boxes, etc.)
+        $sanitizedName = mb_ereg_replace('[^\p{L}\p{M}0-9-]+', '', $dashedName);
+
+        // Merge consecutive dashes
+        return preg_replace('/-+/', '-', $sanitizedName);
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -130,12 +130,14 @@ class User extends Authenticatable implements \Illuminate\Contracts\Auth\MustVer
 
     public function characteristics():BelongsToMany
     {
-        return $this->belongsToMany(CharacteristicsModel::class,
+        return $this->belongsToMany(
+            CharacteristicsModel::class,
             'user_characteristics',
             'user_id',
             'characteristic_id'
         )
-            ->using(UserCharacteristicsModel::class);
+            ->using(UserCharacteristicsModel::class)
+            ->withTimestamps();
     }
 
     public function context()

--- a/database/migrations/2025_04_23_171741_init_user_characteristics_timestamps.php
+++ b/database/migrations/2025_04_23_171741_init_user_characteristics_timestamps.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Populates country
+        DB::statement(<<<SQL
+            UPDATE user_characteristics uc
+                INNER JOIN users u ON uc.user_id = u.id
+            SET uc.created_at = u.updated_at, uc.updated_at = u.updated_at
+            WHERE uc.created_at IS NULL OR uc.updated_at IS NULL;
+        SQL);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/tests/Unit/Forum/ForumTagHelperTest.php
+++ b/tests/Unit/Forum/ForumTagHelperTest.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace Tests\Unit\Forum;
+
+use App\Src\UseCases\Domain\Forum\ForumTagHelper;
+use Tests\TestCase;
+
+class ForumTagHelperTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider tagNameProvider
+     */
+    public function shouldSanitizeTagNames(string $rawTagName, string $expectedTagName)
+    {
+        self::assertEquals($expectedTagName, ForumTagHelper::sanitizeTagName($rawTagName));
+    }
+
+    private function tagNameProvider(): array
+    {
+        return [
+            ['Aviculture (oeufs)', 'Aviculture-oeufs'],
+            ['100% plein air', '100-plein-air'],
+            ['Fertilisation azotée avec la méthode Appi-N', 'Fertilisation-azotée-avec-la-méthode-Appi-N'],
+        ];
+    }
+}


### PR DESCRIPTION
@bertrandgorge 

J'ai ajouté le renseignement des `created_at`/`updated_at` de la table _user_characteristics_ dans l'édition du profil + 1 migration qui initialise avec l'updated_at du profil (juste pour avoir une valeur à mettre).
La commande traite par défaut les user_characteristics créées sur les 15 derniers jours (valeur de l'option --since-x-days). Le CRON configuré tous les soirs à 22h15 est prévu pour traiter les 3 derniers jours (je mets toujours un peu de recouvrement sur ce genre de trucs).

Au déploiement, il faudra :

- jouer la migration
- jouer la commande d'import des caractéristiques depuis le wiki (qui va créer les tags de caractéristiques) `php artisan characteristics:import`
- jouer la commande une première fois avec les profils créés depuis le début : `php artisan characteristics:init-users-subscriptions --since-x-days=3650` (10 ans pour être large)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Users are now automatically subscribed to forum tags that match their profile characteristics.
  - Forum tag names are sanitized to ensure consistency and compatibility with Discourse conventions.

- **Improvements**
  - User-characteristic relationships now track creation and update timestamps.
  - Forum tag subscriptions and user syncs are scheduled daily to process recent changes.

- **Bug Fixes**
  - Ensured all user-characteristic records have valid timestamps.

- **Tests**
  - Added unit tests to verify tag name sanitization logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->