### PR TITLE
Allow up to 32 letters postal codes

### DIFF
--- a/database/migrations/2025_04_25_100211_longer_postal_codes.php
+++ b/database/migrations/2025_04_25_100211_longer_postal_codes.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('contexts', function (Blueprint $table){
+            $table->string('postal_code', 32)->nullable()->default(null)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('contexts', function (Blueprint $table){
+            $table->string('postal_code', 10)->nullable()->default(null)->change();
+        });
+    }
+};


### PR DESCRIPTION
Fixes #265 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Increased the maximum length of postal codes in the contexts table, allowing for longer postal code entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->